### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/isteo-playground/340d83d5-1276-4bb8-9c45-72e40228520f/93c1501a-349d-489e-80f1-c79e63fc71b0/_apis/work/boardbadge/851c5ae9-8da4-40b3-9f65-102fdf58ba90)](https://dev.azure.com/isteo-playground/340d83d5-1276-4bb8-9c45-72e40228520f/_boards/board/t/93c1501a-349d-489e-80f1-c79e63fc71b0/Microsoft.RequirementCategory)
 # Project to try somes things in TypeScript
 
 ## Tech-stack


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#10](https://dev.azure.com/isteo-playground/340d83d5-1276-4bb8-9c45-72e40228520f/_workitems/edit/10). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.